### PR TITLE
Support custom current time if required

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -219,6 +219,7 @@ func newSignature(data []byte, opts ...Option) (*Signature, error) {
 	o := &options{
 		docID:      uuid.NewV1().String(),
 		namespaces: make(Namespaces),
+		timeNow:    currentTime,
 	}
 	for _, opt := range opts {
 		if err := opt(o); err != nil {
@@ -296,7 +297,7 @@ func (s *Signature) buildQualifyingProperties() error {
 		SignedProperties: &SignedProperties{
 			ID: fmt.Sprintf(sigPropertiesIDFormat, s.opts.docID),
 			SignatureProperties: &SignedSignatureProperties{
-				SigningTime: time.Now().UTC().Format(ISO8601),
+				SigningTime: s.opts.timeNow().Format(ISO8601),
 				SigningCertificate: &SigningCertificate{
 					CertDigest: &Digest{
 						Method: &AlgorithmMethod{
@@ -472,4 +473,8 @@ func (s *Signature) buildSignatureValue() error {
 // UnsignedProperties contains ...
 type UnsignedProperties struct {
 	SignatureTimestamp *Timestamp `xml:"xades:UnsignedSignatureProperties>xades:SignatureTimestamp"`
+}
+
+func currentTime() time.Time {
+	return time.Now().UTC()
 }

--- a/signature_test.go
+++ b/signature_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/invopop/xmldsig"
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,23 @@ func TestSignature(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.NotEmpty(t, getTimestamp(signature))
+	})
+
+	t.Run("should support setting a fixed signing time", func(t *testing.T) {
+		ts, err := time.Parse(time.RFC3339, "2022-08-05T13:51:00+02:00")
+		require.NoError(t, err)
+		signature, err := xmldsig.Sign(data,
+			xmldsig.WithDocID("test"),
+			xmldsig.WithCertificate(certificate),
+			xmldsig.WithXAdES(xadesConfig()),
+			xmldsig.WithCurrentTime(func() time.Time {
+				return ts
+			}),
+		)
+		assert.Nil(t, err)
+		// This is mostly useful for getting back fixed results, so
+		// we can safely compare the final signature here.
+		assert.Contains(t, signature.Value.Value, "r1GyPRqPZN3LXZ7SKpENUtI7dSXA83aIlza7fG2c1XGnHOK4HNweEDifqg65owS6TYLn7eZtiUXMHN49CUnZ7YDo9O")
 	})
 }
 

--- a/xmldsig.go
+++ b/xmldsig.go
@@ -2,6 +2,7 @@ package xmldsig
 
 import (
 	"errors"
+	"time"
 
 	"github.com/beevik/etree"
 )
@@ -18,6 +19,7 @@ type options struct {
 	timestampURL string
 	cert         *Certificate
 	xades        *XAdESConfig
+	timeNow      func() time.Time
 }
 
 // XAdESSignerRole defines the accepted signer roles
@@ -79,6 +81,16 @@ func WithXAdES(config *XAdESConfig) Option {
 func WithTimestamp(url string) Option {
 	return func(o *options) error {
 		o.timestampURL = url
+		return nil
+	}
+}
+
+// WithCurrentTime allows a callback to be provided in order to using a
+// different signing time method. This is especially useful for testing.
+// Default is to provide `time.Now().UTC()`.
+func WithCurrentTime(fn func() time.Time) Option {
+	return func(o *options) error {
+		o.timeNow = fn
 		return nil
 	}
 }


### PR DESCRIPTION
* Makes it much easier to test signatures with consistent results.