### PR TITLE
Make policy optional for xades

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.48
+          version: v1.52

--- a/signature.go
+++ b/signature.go
@@ -337,6 +337,10 @@ func (s *Signature) buildQualifyingProperties() error {
 
 func (s *Signature) xadesPolicyIdentifier() *PolicyIdentifier {
 	policy := s.opts.xades.Policy
+	if policy == nil {
+		return nil
+	}
+
 	return &PolicyIdentifier{
 		SigPolicyID: &SigPolicyID{
 			Identifier:  policy.URL,


### PR DESCRIPTION
- Currently, xades config requires that the policy be defined. 
- This is a problem for Italy that requires the xades format but doest not have an associated policy. 