### PR TITLE
Extract XAdES Signer Roles

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,12 @@ jobs:
           username: ${{ secrets.GO_MOD_USER }}
           password: ${{ secrets.GO_MOD_PASS }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.17.5"
+
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
 	}
 	// Using XAdES FacturaE example policy config
 	xades := &xmldsig.XAdESConfig{
-		Role:        xmldsig.XAdESThirdParty,
+		Role:        xmldsig.XAdESSignerRole("third party"),
 		Description: "test",
 		Policy: &xmldsig.XAdESPolicyConfig{
 			URL:         "http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf",

--- a/signature.go
+++ b/signature.go
@@ -311,9 +311,6 @@ func (s *Signature) buildQualifyingProperties() error {
 					},
 				},
 				PolicyIdentifier: s.xadesPolicyIdentifier(),
-				SignerRole: &SignerRole{
-					ClaimedRoles: &Roles{ClaimedRole: []string{s.opts.xades.Role.String()}},
-				},
 			},
 			DataObjectProperties: &DataObjectFormat{
 				ObjectReference: "#" + s.referenceID,
@@ -329,6 +326,13 @@ func (s *Signature) buildQualifyingProperties() error {
 			},
 		},
 	}
+
+	if s.opts.xades.Role != "" {
+		qp.SignedProperties.SignatureProperties.SignerRole = &SignerRole{
+			ClaimedRoles: &Roles{ClaimedRole: []string{s.opts.xades.Role.String()}},
+		}
+	}
+
 	s.Object = &Object{
 		QualifyingProperties: qp,
 	}

--- a/signature_test.go
+++ b/signature_test.go
@@ -84,7 +84,7 @@ func TestSignature(t *testing.T) {
 
 func xadesConfig() *xmldsig.XAdESConfig {
 	return &xmldsig.XAdESConfig{
-		Role:        xmldsig.XAdESThirdParty,
+		Role:        xmldsig.XAdESSignerRole("third party"),
 		Description: "test",
 		Policy: &xmldsig.XAdESPolicyConfig{
 			URL:         "http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf",

--- a/signature_test.go
+++ b/signature_test.go
@@ -80,6 +80,29 @@ func TestSignature(t *testing.T) {
 		// we can safely compare the final signature here.
 		assert.Contains(t, signature.Value.Value, "r1GyPRqPZN3LXZ7SKpENUtI7dSXA83aIlza7fG2c1XGnHOK4HNweEDifqg65owS6TYLn7eZtiUXMHN49CUnZ7YDo9O")
 	})
+
+	t.Run("should not set a signer role when not provided", func(t *testing.T) {
+		xades := xadesConfig()
+		xades.Role = ""
+		signature, err := xmldsig.Sign(data,
+			xmldsig.WithCertificate(certificate),
+			xmldsig.WithXAdES(xades),
+		)
+		assert.Nil(t, err)
+		assert.Nil(t, signature.Object.QualifyingProperties.SignedProperties.SignatureProperties.SignerRole)
+	})
+
+	t.Run("should set a signer role when provided", func(t *testing.T) {
+		signature, err := xmldsig.Sign(data,
+			xmldsig.WithCertificate(certificate),
+			xmldsig.WithXAdES(xadesConfig()),
+		)
+		assert.Nil(t, err)
+		assert.Equal(t,
+			"third party",
+			signature.Object.QualifyingProperties.SignedProperties.
+				SignatureProperties.SignerRole.ClaimedRoles.ClaimedRole[0])
+	})
 }
 
 func xadesConfig() *xmldsig.XAdESConfig {

--- a/xmldsig.go
+++ b/xmldsig.go
@@ -25,13 +25,6 @@ type options struct {
 // XAdESSignerRole defines the accepted signer roles
 type XAdESSignerRole string
 
-// Pre-defined XAdES Signer Roles
-const (
-	XAdESSupplier   XAdESSignerRole = "supplier"
-	XAdESCustomer   XAdESSignerRole = "customer"
-	XAdESThirdParty XAdESSignerRole = "third party"
-)
-
 // XAdESConfig defines what is expected for the configuration.
 type XAdESConfig struct {
 	Role        XAdESSignerRole    `json:"role"`


### PR DESCRIPTION
* Removes predefined XAdES Signer Roles. Clients are free to define the ones they want to use.
* Makes the Signer Role optional.